### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ If you have an Android phone, your WhatsApp database is stored in a location of 
 
         ```
         $ mkdir tmp
-        $ cd tmp
         $ curl -o tmp/EnhancedWhatsApp.apk https://github.com/Dexter2389/whatsapp-backup-chat-viewer/raw/main/assets/EnhancedWhatsApp.apk
         ```
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ If you have an Android phone, your WhatsApp database is stored in a location of 
 
         ```
         $ mkdir tmp
-        $ curl -o tmp/EnhancedWhatsApp.apk https://github.com/Dexter2389/whatsapp-backup-chat-viewer/raw/main/assets/EnhancedWhatsApp.apk
+        $ curl -L -o tmp/EnhancedWhatsApp.apk https://github.com/Dexter2389/whatsapp-backup-chat-viewer/raw/main/assets/EnhancedWhatsApp.apk
         ```
 
-        <!-- $ curl -o tmp/EnhancedWhatsApp.apk http://dl.imobie.com/android/specified-app.apk -->
+        <!-- $ curl -L -o tmp/EnhancedWhatsApp.apk http://dl.imobie.com/android/specified-app.apk -->
 
       - Uninstall existing whatsapp app and install the enhanced app.
         ```


### PR DESCRIPTION
I was trying to follow the instructions without rooted phone and found tiny bugs in the readme.
See commit messages of the 2 commits.

At the end it did not work due to a mismatch between the APK’s native libraries and the device's architecture.

$ adb install -r -d tmp/EnhancedWhatsApp.apk
adb: failed to install tmp/EnhancedWhatsApp.apk: Failure [INSTALL_FAILED_NO_MATCHING_ABIS: INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries, res=-113]
Performing Streamed Install
